### PR TITLE
Fix: default number of items is 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once installed, it can be used in a template as simply as:
 - `placeholder` (optional): A placeholder 
 - `disabled` (optional): true/false
 - `name` (optional): An input name | default: `dropdown`
-- `maxItem` (optional): Max item to show | default: `10`
+- `maxItem` (optional): Max item to show | default: `6`
 
 ### Events
 

--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -57,7 +57,7 @@
       maxItem: {
         type: Number,
         required: false,
-        default: 10,
+        default: 6,
         note: 'Max items showing'
       }
     },


### PR DESCRIPTION
As requested in https://github.com/romainsimon/vue-simple-search-dropdown/pull/3/ the default number of items should remain 6